### PR TITLE
Fix entity annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# PyCharm project settings
+.idea/
+
 # mkdocs documentation
 /site
 

--- a/taipo/cli/keyboard.py
+++ b/taipo/cli/keyboard.py
@@ -19,18 +19,18 @@ from taipo.common import (
 # nlpaug will add spaces between the entity annotations (e.g. 'going to [New York] (city )'), which will
 # lead to Rasa not picking them up as training examples.
 CUSTOM_DETOKENIZER_REGEXS = [
-    (re.compile(r'\s([\[\(\{\<])\s'), r' \g<1>'),  # Left bracket
-    (re.compile(r'\s([\]\)\}\>])\s'), r'\g<1> '),  # right bracket
-    (re.compile(r'^\[\s'), r'['),  # left square bracket at beginning of sentence
-    (re.compile(r'\s\)$'), r')'),  # right round bracket at the end of sentence
-    (re.compile(r'\] \('), r']('),  # entity annotation of the form "]("
-    (re.compile(r'\s([.,:;?!%]+)([ \'"`])'), r'\1\2'),  # End of sentence
-    (re.compile(r'\s([.,:;?!%]+)$'), r'\1'),  # End of sentence
+    (re.compile(r"\s([\[\(\{\<])\s"), r" \g<1>"),  # Left bracket
+    (re.compile(r"\s([\]\)\}\>])\s"), r"\g<1> "),  # right bracket
+    (re.compile(r"^\[\s"), r"["),  # left square bracket at beginning of sentence
+    (re.compile(r"\s\)$"), r")"),  # right round bracket at the end of sentence
+    (re.compile(r"\] \("), r"]("),  # entity annotation of the form "]("
+    (re.compile(r'\s([.,:;?!%]+)([ \'"`])'), r"\1\2"),  # End of sentence
+    (re.compile(r"\s([.,:;?!%]+)$"), r"\1"),  # End of sentence
 ]
 
 
 def custom_reverse_tokenizer(tokens):
-    text = ' '.join(tokens)
+    text = " ".join(tokens)
     for regex, sub in CUSTOM_DETOKENIZER_REGEXS:
         text = regex.sub(sub, text)
     return text.strip()
@@ -48,7 +48,6 @@ def add_spelling_errors(dataf, aug, text_col="text"):
     texts = list(dataf["text"])
     names = entity_names(texts) + curly_entity_items(texts)
     aug.stopwords = names
-    aug.reverse_tokenizer = custom_reverse_tokenizer
     return dataf.assign(**{text_col: lambda d: aug.augment(list(d[text_col]), n=1)})
 
 
@@ -77,6 +76,7 @@ def augment(
         include_numeric=False,
         include_upper_case=False,
         lang=lang,
+        reverse_tokenizer=custom_reverse_tokenizer,
     )
     dataf = nlu_path_to_dataframe(file)
     (

--- a/taipo/cli/keyboard.py
+++ b/taipo/cli/keyboard.py
@@ -18,10 +18,11 @@ from taipo.common import (
 # NOTE: the following custom implementation of a reverse tokenizer is necessary, since otherwise
 # nlpaug will add spaces between the entity annotations (e.g. 'going to [New York] (city )'), which will
 # lead to Rasa not picking them up as training examples.
-DETOKENIZER_REGEXS = [
+CUSTOM_DETOKENIZER_REGEXS = [
     (re.compile(r'\s([\[\(\{\<])\s'), r' \g<1>'),  # Left bracket
     (re.compile(r'\s([\]\)\}\>])\s'), r'\g<1> '),  # right bracket
-    (re.compile(r'\s\)$'), r')'),  # right bracket at the end of sentence
+    (re.compile(r'^\[\s'), r'['),  # left square bracket at beginning of sentence
+    (re.compile(r'\s\)$'), r')'),  # right round bracket at the end of sentence
     (re.compile(r'\] \('), r']('),  # entity annotation of the form "]("
     (re.compile(r'\s([.,:;?!%]+)([ \'"`])'), r'\1\2'),  # End of sentence
     (re.compile(r'\s([.,:;?!%]+)$'), r'\1'),  # End of sentence
@@ -30,7 +31,7 @@ DETOKENIZER_REGEXS = [
 
 def custom_reverse_tokenizer(tokens):
     text = ' '.join(tokens)
-    for regex, sub in DETOKENIZER_REGEXS:
+    for regex, sub in CUSTOM_DETOKENIZER_REGEXS:
         text = regex.sub(sub, text)
     return text.strip()
 

--- a/taipo/common.py
+++ b/taipo/common.py
@@ -113,7 +113,10 @@ def gen_curly_ents(text):
         ent = text[sq1 : sq1 + sq2 + 1]
         curly_bit = text[sq1 + sq2 + br1 : sq1 + sq2 + br1 + br2 + 1]
         yield ent, curly_bit
-        text = text[sq1 + sq2 + br1 + br2 :]
+        if curly_bit != "":
+            text = text[sq1 + sq2 + br1 + br2 :]
+        else:
+            text = text[sq1 + sq2 :]
 
 
 def curly_entity_items(texts):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -73,7 +73,9 @@ def test_replace_ent_assignment(going_in, going_out):
             "[js]{ent:proglang, value:javascript} n [python]{ent:proglang, value:python}",
             ["ent", "proglang", "value", "python", "javascript"],
         ),
+        ("[r](proglang)", []),
     ],
 )
+@pytest.mark.timeout(5)
 def test_curly_entity_items(going_in, going_out):
     assert set(curly_entity_items([going_in])) == set(going_out)


### PR DESCRIPTION
Fixes #30 

The two issues getting fixed in this PR are:
- Entering an infinte loop in `common.curly_entity_items` if there are no curly entity annotations and a single character entity with round bracket annotation, e.g. `i use [r](prolang)`. This is fixed by distinguishing between curly and non-curly annotations in the above function.
- `nlpaug` adding spaces between entity annotations due to the default detokenizer, such that output looks like this: `i use [python] (prolang )`. This is fixed by adding a custom detokenizer that removes spaces related to such entity annotations.